### PR TITLE
new HAMT implementation:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ port.scm: port.rktl $(CONVERT_DEPS)
 hash-demo: core.so
 	scheme core.so hash-demo.ss
 
+set-demo: core.so
+	scheme core.so set-demo.ss
+
 struct-demo: core.so
 	scheme core.so struct-demo.ss
 
@@ -70,6 +73,8 @@ CORE_SRCS = core-constant.ss \
             core-struct.ss \
             core-procedure.ss \
             core-hamt.ss \
+            core-immutable-hash.ss \
+            core-immutable-set.ss \
             core-hash.ss \
             core-thread-cell.ss \
             core-parameter.ss \

--- a/core-control.ss
+++ b/core-control.ss
@@ -38,9 +38,9 @@
               (eq? k (mark-stack-frame-k mark-stack)))
          (begin
            (set-mark-stack-frame-table! mark-stack
-                                        (hamt-set (mark-stack-frame-table mark-stack)
-                                                  key
-                                                  val))
+                                        (immutable-hash-set (mark-stack-frame-table mark-stack)
+							    key
+							    val))
            (set-mark-stack-frame-flat! mark-stack #f)
            (proc))
          (begin0
@@ -79,7 +79,7 @@
              empty-parameterization
              none-v)]
         [else
-         (let ([v (hamt-ref (car marks) key none)])
+         (let ([v (immutable-hash-ref (car marks) key none)])
            (if (eq? v none)
                (loop (cdr marks))
                v))]))]))

--- a/core-immutable-hash.ss
+++ b/core-immutable-hash.ss
@@ -1,0 +1,202 @@
+;; ARRAYS FOR IMMUTABLE HASHES (A.K.A DICT-HAMTs)
+;; Dict-hamts store key/value pairs in a flat array where
+;; the key is at (vector) index 2i and the value at 2i + 1.
+;; If the array index holds a child node, that will be in the value
+;; slot, and the key slot will contain the unique NON-KEY value.
+(define NON-KEY (gensym))
+
+(define-syntax dict-array
+  (syntax-rules ()
+    [(_ [k1 v1] [k2 v2]) (vector k1 v1 k2 v2)]
+    [(_ c) (vector NON-KEY c)]))
+
+(define (dict-array-length arr)
+  (fxsrl (vector-length arr) 1))
+
+(define (dict-array-ref-key arr i)
+  (vector-ref arr (fx* 2 i)))
+
+(define (dict-array-ref-value arr i)
+  (vector-ref arr (fx1+ (fx* 2 i))))
+
+(define (dict-array-ref arr i)
+  (let ([idx (fx* 2 i)])
+    (values (vector-ref arr idx)
+	    (vector-ref arr (fx1+ idx)))))
+
+(define (dict-array-set! arr i key val)
+    (let ([idx (fx* 2 i)])
+      (vector-set! arr idx key)
+      (vector-set! arr (fx1+ idx) val)))
+
+(define-syntax dict-array-case
+  (syntax-rules ()
+    [(_ arr i [(entry k v) e1 ...] [(child c) e2 ...])
+     (let*-values ([(idx) i]
+		   [(k v) (dict-array-ref arr idx)])
+       (cond [(eq? NON-KEY k)
+	      (let ([c v])
+		e2 ...)]
+	     [else e1 ...]))]))
+
+(define (dict-array-replace arr i key val)
+  (let ([new (vector-copy arr)])
+    (dict-array-set! new i key val)
+    new))
+
+(define (dict-array-replace-value arr i val)
+  (let ([new (vector-copy arr)])
+    (vector-set! new (fx1+ (fx* 2 i)) val)
+    new))
+
+(define (dict-array-set-child arr i child)
+  (dict-array-replace arr i NON-KEY child))
+
+(define dict-array-replace-child dict-array-replace-value)
+
+(define (make-dict-array len)
+  (make-vector (fx* 2 len)))
+
+(define (dict-array-copy! dst dst-start src src-start src-end)
+  (vector-copy! dst (fx* dst-start 2) src (fx* src-start 2) (fx* src-end 2)))
+
+(define (dict-array-insert arr i key val)
+  (let ([new (make-dict-array (fx1+ (dict-array-length arr)))])
+    (dict-array-copy! new 0 arr 0 i)
+    (dict-array-set! new i key val)
+    (dict-array-copy! new (fx1+ i) arr i (dict-array-length arr))
+    new))
+
+(define (dict-array-remove arr i)
+  (let ([new (make-dict-array (fx1- (dict-array-length arr)))])
+    (dict-array-copy! new 0 arr 0 i)
+    (dict-array-copy! new i arr (fx1+ i) (dict-array-length arr))
+    new))
+
+;; DICT-HAMT POPCOUNT
+(define (popcount16 x)
+  (let* ([x (fx- x (fxlogand (fxsrl x 1) #x5555))]
+	 [x (fx+ (fxlogand x #x3333) (fxlogand (fxsrl x 2) #x3333))]
+	 [x (fxlogand (fx+ x (fxsrl x 4)) #x0f0f)]
+	 [x (fx+ x (fxsrl x 8))])
+    (fxlogand x #x1f)))
+
+;; DICT NODE TYPES
+;;
+;; bnodes
+(define-record-type dict-bnode
+  [fields (immutable array)
+	  (immutable bitmap)
+	  (immutable count)])
+
+(define-record-type dict-bnode/equal
+  [parent dict-bnode]
+  [sealed #t])
+
+(define-record-type dict-bnode/eqv
+  [parent dict-bnode]
+  [sealed #t])
+
+(define-record-type dict-bnode/eq
+  [parent dict-bnode]
+  [sealed #t])
+
+;; cnodes
+(define-record-type dict-cnode
+  [fields (immutable array)
+	  (immutable hashcode)]
+  [sealed #t])
+
+;; DICT HAMTs
+(define-values
+  (empty-hash
+   empty-hasheqv
+   empty-hasheq
+
+   immutable-hash?
+   immutable-hash-equal?
+   immutable-hash-eqv?
+   immutable-hash-eq?
+
+   immutable-hash=?
+   immutable-hash-hash-code
+
+   immutable-hash-count
+   immutable-hash-has-key?
+   immutable-hash-ref
+   immutable-hash-set
+   immutable-hash-remove
+   immutable-hash-keys-subset?
+
+   immutable-hash-foldk
+
+   immutable-hash-iterate-first
+   immutable-hash-iterate-next
+   immutable-hash-iterate-key
+   immutable-hash-iterate-value
+   immutable-hash-iterate-key+value
+   immutable-hash-iterate-pair
+
+   unsafe-immutable-hash-iterate-first
+   unsafe-immutable-hash-iterate-next
+   unsafe-immutable-hash-iterate-key
+   unsafe-immutable-hash-iterate-value
+   unsafe-immutable-hash-iterate-key+value
+   unsafe-immutable-hash-iterate-pair)
+
+  (make-hamt-impl
+   [4 popcount16]
+
+   [dict-bnode? dict-bnode-array dict-bnode-bitmap dict-bnode-count
+    dict-bnode/equal? dict-bnode/eqv? dict-bnode/eq?
+    make-dict-bnode/equal make-dict-bnode/eqv make-dict-bnode/eq
+    dict-cnode? dict-cnode-array dict-cnode-hashcode
+    make-dict-cnode]
+
+   [dict-array dict-array-length
+    dict-array-case dict-array-ref-key dict-array-ref-value
+    dict-array-replace dict-array-replace-value
+    dict-array-set-child dict-array-replace-child
+    dict-array-insert dict-array-remove]))
+
+;; CONSTRUCTORS
+(define-syntax define-hash-constructors
+  (syntax-rules ()
+    [(_ vararg-constructor list-constructor empty)
+     (begin
+       (define (vararg-constructor . kvs)
+         (let loop ([kvs kvs] [h empty])
+           (cond
+            [(null? kvs) h]
+            [else
+             (loop (cddr kvs) (immutable-hash-set h (car kvs) (cadr kvs)))])))
+
+       (define list-constructor
+         (case-lambda
+	  [() (vararg-constructor)]
+	  [(assocs)
+	   (let loop ([h (vararg-constructor)] [assocs assocs])
+	     (if (null? assocs)
+		 h
+		 (loop (immutable-hash-set h (caar assocs) (cdar assocs))
+		       (cdr assocs))))])))]))
+
+(define-hash-constructors hash make-immutable-hash empty-hash)
+(define-hash-constructors hasheqv make-immutable-hasheqv empty-hasheqv)
+(define-hash-constructors hasheq make-immutable-hasheq empty-hasheq)
+
+;; FOR-EACH AND MAP
+(define (immutable-hash-for-each h proc)
+  (immutable-hash-foldk h
+			(lambda (key val nil k)
+			  (proc key val)
+			  (k nil))
+			(void)
+			(lambda (x) x)))
+
+(define (immutable-hash-map h proc)
+  (immutable-hash-foldk h
+			(lambda (key val xs k)
+			  (k (cons (proc key val) xs)))
+			'()
+			(lambda (xs) xs)))

--- a/core-immutable-set.ss
+++ b/core-immutable-set.ss
@@ -1,0 +1,194 @@
+;; ARRAYS FOR SET-HAMTS
+;; Set-hamts only store keys and child nodes -- no values.
+(define-syntax set-array
+  (syntax-rules ()
+    [(_ [k1 v1] [k2 v2]) (vector k1 k2)]
+    [(_ child) (vector child)]))
+
+(define set-array-length vector-length)
+(define set-array-ref-key vector-ref)
+
+;; Can only be called when a value is known to
+;; exist for the given key. That means it's always #t
+;; for sets.
+(define (set-array-ref-value arr i)
+  #t)
+
+(define-syntax set-array-case
+  (syntax-rules ()
+    [(_ arr i [(entry k v) e1 ...] [(child c) e2 ...])
+     (let* ([idx i]
+	    [c (vector-ref arr idx)])
+       (cond [(immutable-set-node? c) e2 ...]
+	     [else
+	      (let ([k c]
+		    [v #t])
+		e1 ...)]))]))
+
+(define (set-array-replace arr i key val)
+  (let ([new (vector-copy arr)])
+    (vector-set! arr i key)
+    new))
+
+;; should never be called
+(define (set-array-replace-value arr i val)
+  arr)
+
+(define (set-array-set-child arr i child)
+  (set-array-replace arr i child #f))
+
+(define set-array-replace-child set-array-set-child)
+
+(define (set-array-insert arr i key val)
+  (let ([new (make-vector (fx1+ (vector-length arr)))])
+    (vector-copy! new 0 arr 0 i)
+    (vector-set! new i key)
+    (vector-copy! new (fx1+ i) arr i (vector-length arr))
+    new))
+
+(define (set-array-remove arr i)
+  (let ([new (make-vector (fx1- (vector-length arr)))])
+    (vector-copy! new 0 arr 0 i)
+    (vector-copy! new i arr (fx1+ i) (vector-length arr))
+    new))
+
+;; POPCOUNT
+(define (popcount32 x)
+  (let* ([x (fx- x (fxlogand (fxsrl x 1) #x55555555))]
+	 [x (fx+ (fxlogand x #x33333333) (fxlogand (fxsrl x 2) #x33333333))]
+	 [x (fxlogand (fx+ x (fxsrl x 4)) #x0f0f0f0f)]
+	 [x (fx+ x (fxsrl x 8))]
+	 [x (fx+ x (fxsrl x 16))])
+    (fxlogand x #x3f)))
+
+
+;; SET NODE TYPES
+;;
+;; bnodes
+(define-record-type set-bnode
+  [fields (immutable array)
+	  (immutable bitmap)
+	  (immutable count)])
+
+(define-record-type set-bnode/equal
+  [parent set-bnode]
+  [sealed #t])
+
+(define-record-type set-bnode/eqv
+  [parent set-bnode]
+  [sealed #t])
+
+(define-record-type set-bnode/eq
+  [parent set-bnode]
+  [sealed #t])
+
+;; cnodes
+(define-record-type set-cnode
+  [fields (immutable array)
+	  (immutable hashcode)]
+  [sealed #t])
+
+(define (immutable-set-node? x)
+  (or (set-bnode? x)
+      (set-cnode? x)))
+
+
+;; IMMUTABLE SET HAMTs
+(define-values
+  (empty-set
+   empty-seteqv
+   empty-seteq
+
+   immutable-set?
+   immutable-set-equal?
+   immutable-set-eqv?
+   immutable-set-eq?
+
+   immutable-set=?
+   immutable-set-hash-code
+
+   immutable-set-count
+   immutable-set-member?
+   immutable-set-ref
+   immutable-set-put
+   immutable-set-remove
+   immutable-set-subset?
+
+   immutable-set-foldk
+
+   set-iterate-first
+   set-iterate-next
+   set-iterate-key
+   set-iterate-value
+   set-iterate-key+value
+   set-iterate-pair
+
+   unsafe-set-iterate-first
+   unsafe-set-iterate-next
+   unsafe-set-iterate-key
+   unsafe-set-iterate-value
+   unsafe-set-iterate-key+value
+   unsafe-set-iterate-pair)
+
+  (make-hamt-impl
+   [5 popcount32]
+
+   [set-bnode? set-bnode-array set-bnode-bitmap set-bnode-count
+    set-bnode/equal? set-bnode/eqv? set-bnode/eq?
+    make-set-bnode/equal make-set-bnode/eqv make-set-bnode/eq
+    set-cnode? set-cnode-array set-cnode-hashcode
+    make-set-cnode]
+
+   [set-array set-array-length
+    set-array-case set-array-ref-key set-array-ref-value
+    set-array-replace set-array-replace-value
+    set-array-set-child set-array-replace-child
+    set-array-insert set-array-remove]))
+
+(define (immutable-set-add s x)
+  (immutable-set-put s x #t))
+
+(define (immutable-set-empty? s)
+  (zero? (immutable-set-count s)))
+
+(define (immutable-set-clear s)
+  (cond [(immutable-set-equal? s) empty-set]
+	[(immutable-set-eqv? s)   empty-seteqv]
+	[else                     empty-seteq]))
+
+(define (immutable-set-proper-subset? a b)
+  (and (< (immutable-set-count a)
+	  (immutable-set-count b))
+       (immutable-set-subset? a b)))
+
+(define (immutable-set-fold s proc acc)
+  (immutable-set-foldk
+   s
+   (lambda (key _ acc k)
+     (k (proc key acc)))
+   acc
+   (lambda (x) x)))
+
+(define (set . xs)
+  (fold-left
+   (lambda (x s) (immutable-set-add s x))
+   empty-set
+   xs))
+
+(define (seteqv . xs)
+  (fold-left
+   (lambda (x s) (immutable-set-add s x))
+   empty-seteqv
+   xs))
+
+(define (seteq . xs)
+  (fold-left
+   (lambda (x s) (immutable-set-add s x))
+   empty-seteq
+   xs))
+
+(define set-member? immutable-set-member?)
+(define set-add immutable-set-add)
+(define set-remove immutable-set-remove)
+(define set-clear immutable-set-clear)
+(define subset? immutable-set-subset?)

--- a/core-immutable-set.ss
+++ b/core-immutable-set.ss
@@ -131,7 +131,7 @@
    unsafe-set-iterate-pair)
 
   (make-hamt-impl
-   [5 popcount32]
+   [4 popcount16]
 
    [set-bnode? set-bnode-array set-bnode-bitmap set-bnode-count
     set-bnode/equal? set-bnode/eqv? set-bnode/eq?

--- a/core-immutable.ss
+++ b/core-immutable.ss
@@ -2,7 +2,7 @@
 (define immutables (make-weak-eq-hashtable))
 
 (define (immutable? v)
-  (or (hamt? v)
+  (or (immutable? v)
       (and (or (string? v)
                (bytes? v)
                (vector? v)

--- a/core-parameter.ss
+++ b/core-parameter.ss
@@ -10,17 +10,18 @@
   (let loop ([ht (parameterization-ht p)] [args args])
     (cond
      [(null? args) (make-parameterization ht)]
-     [else (loop (hamt-set ht (car args) (make-thread-cell (cadr args)))
+     [else (loop (immutable-hash-set ht (car args) (make-thread-cell (cadr args)))
                  (cddr args))])))
 
 (define (parameter-cell key)
-  (hamt-ref (parameterization-ht
-             (continuation-mark-set-first
-              #f
-              parameterization-key
-              empty-parameterization))
-            key
-            #f))
+  (immutable-hash-ref
+   (parameterization-ht
+    (continuation-mark-set-first
+     #f
+     parameterization-key
+     empty-parameterization))
+   key
+   #f))
 
 (define make-parameter
   (case-lambda
@@ -29,7 +30,7 @@
      (let ([default-c (make-thread-cell v)])
        (define self
          (case-lambda
-           [() 
+           [()
             (let ([c (or (parameter-cell self)
                          default-c)])
               (thread-cell-ref c))]

--- a/core.sls
+++ b/core.sls
@@ -68,7 +68,7 @@
           procedure-arity-includes?
           procedure-arity
           procedure-extract-target
-          
+
           raise-argument-error
           raise-arguments-error
           raise-result-error
@@ -132,6 +132,11 @@
           ;; For intern tables:
           weak-hash-ref-key
 
+          set seteqv seteq
+	  set-member? set-add set-remove
+	  set-clear
+	  subset?
+
           bytes bytes?
           bytes-length
           make-bytes
@@ -187,7 +192,7 @@
           pseudo-random-generator?
 
           mpair? mcons mcar mcdr set-mcar! set-mcdr!
-          
+
           correlated?
           correlated-source
           correlated-line
@@ -280,7 +285,7 @@
           unsafe-vector*-set!
           unsafe-vector-length
           unsafe-vector*-length
-          
+
           unsafe-fxvector-ref
           unsafe-fxvector-set!
 
@@ -330,6 +335,8 @@
   (include "core-struct.ss")
   (include "core-procedure.ss")
   (include "core-hamt.ss")
+  (include "core-immutable-hash.ss")
+  (include "core-immutable-set.ss")
   (include "core-hash.ss")
   (include "core-thread-cell.ss")
   (include "core-control.ss")
@@ -349,6 +356,6 @@
   (include "core-memory.ss")
   (include "core-system.ss")
   (include "core-unsafe.ss")
-  
+
   (set-base-exception-handler!)
   (set-primitive-applicables!))

--- a/set-demo.ss
+++ b/set-demo.ss
@@ -1,0 +1,62 @@
+(import (core))
+
+(define-syntax time
+  (syntax-rules ()
+    [(_ expr1 expr ...)
+     (let-values ([(v cpu user gc) (time-apply (lambda () expr1 expr ...) null)])
+       (printf "cpu time: ~s real time: ~s gc time: ~s\n" cpu user gc)
+       (apply values v))]))
+
+(define l (values (let loop ([i 1000])
+		    (if (zero? i)
+			'()
+			(cons i (loop (sub1 i)))))))
+
+(printf "large sets\n")
+(time
+ (let loop ([j 1000])
+   (define numbers
+     (let loop ([s (seteqv)] [l l])
+       (if (null? l)
+           s
+           (loop (set-add s (car l)) (cdr l)))))
+   (unless (zero? j)
+     (let loop ([v #f] [i 1000])
+       (if (zero? i)
+           v
+           (loop (set-member? numbers i) (sub1 i))))
+     (loop (sub1 j)))))
+(time
+ (let loop ([j 1000])
+   (define numbers
+     (let loop ([s (seteq)] [l l])
+       (if (null? l)
+           s
+           (loop (set-add s l) (cdr l)))))
+   (unless (zero? j)
+     (let loop ([v #f] [l l])
+       (if (null? l)
+           v
+           (loop (set-member? numbers l) (cdr l))))
+     (loop (sub1 j)))))
+
+(printf "small tables\n")
+(time
+ (let loop ([j 100000])
+   (define numbers
+     (let loop ([s (seteqv)] [i 10])
+       (if (zero? i)
+           s
+           (loop (set-add s i) (sub1 i)))))
+   (define numbers2
+     (let loop ([s (seteqv)] [i 10])
+       (if (zero? i)
+           s
+           (loop (set-add s i) (sub1 i)))))
+   (unless (zero? j)
+     (let loop ([v #f] [i 10])
+       (if (zero? i)
+           v
+           (and (subset? numbers numbers2)
+                (loop (set-member? numbers i) (sub1 i)))))
+     (loop (sub1 j)))))


### PR DESCRIPTION
- Specialized versions for immutable hashes and sets. Sets
do not store values. Hashes store keys and values directly
in the node array, instead of in an `entry` struct.

- Procedures do not pass equality predicates and hash-code
functions. Instead, they pass a symbolic `eqtype`, and we
dispatch on that to use the correct predicate/hash-code.
(We could also specialize all of the procedures for their
eqtype. I did this is a previous branch. It is a bit faster
but perhaps not enough to justify so much code duplication.

- Significantly faster than existing version on large table
examples in hash-demo.ss, but slower for small table examples.
My *guess* is that the existing specialization for #t values
accounts for that, since all of the values in those examples
use #t values. However, I haven't verified that this is the
reason for the performance difference. The new specialized
set-hamt is faster than either hash implementation on those
examples.