### PR TITLE
Added a lock to mutable hash tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ CORE_SRCS = core-constant.ss \
             core-procedure.ss \
             core-hamt.ss \
             core-hash.ss \
+	    core-lock.ss \
             core-thread-cell.ss \
             core-parameter.ss \
             core-control.ss \

--- a/core-lock.ss
+++ b/core-lock.ss
@@ -1,0 +1,19 @@
+;; locking code for core-hash.ss
+
+;; https://lwn.net/Articles/590243/
+;; Synchronization Without Contention Mellor-Crummey Scott (MCS lock)
+;; eventually 
+#|
+(define-record mcs-spinlock (next locked?))
+
+(define (create-mcs-spinlock) (make-mcs-spinlock #f #f))
+|#
+
+(define (make-lock)
+  (make-mutex))
+
+(define (lock-acquire lock)
+  (mutex-acquire lock))
+
+(define (lock-release lock)
+  (mutex-release lock))

--- a/core.sls
+++ b/core.sls
@@ -322,6 +322,7 @@
   (include "core-procedure.ss")
   (include "core-hamt.ss")
   (include "core-hash.ss")
+  (include "core-lock.ss")
   (include "core-thread-cell.ss")
   (include "core-control.ss")
   (include "core-parameter.ss")


### PR DESCRIPTION
Added a lock to the mutable hash table implementation in core-hash.  Should provide the same concurrent modification guarantees that are stated in the docs.  Added locks to:
1. hash-set!
2. hash-remove!
3. hash-clear!   (According to docs a semaphore is not used to guard traversal as whole, but I assumed one was needed to modify keys field of record)
4. hash-copy (Assumed having hashtable change while being copied was bad)
5. prepare-iterate (while updating record fields)

Lock is currently just chez's mutex, but I plan to replace this with a better performing lock (MCS). Lock is in core-lock
